### PR TITLE
Fix login typo (Issue #1)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "cmake.sourceDirectory": "C:/Github Desktop/safana_bekam_management_app/linux"
+}

--- a/lib/screen/login/login_screen.dart
+++ b/lib/screen/login/login_screen.dart
@@ -54,7 +54,7 @@ class _LoginScreenState extends State<LoginScreen> {
                   )
                 ],
               ),
-              _buildButton('LOG MASUK', () => controller.submit()),
+              _buildButton('LOGIN', () => controller.submit()),
             ],
           ),
         ),


### PR DESCRIPTION
Fixes #1, fix the typo on button login from "LOG MASUK" to "LOGIN".